### PR TITLE
Adding new signup form and conditional logic to display

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "homepage": "https://github.com/auth0/contact-form#readme",
   "dependencies": {
-    "bootstrap": "^3.3.6",
+    "bootstrap": "^3.3.7",
+    "jquery": "^2.2.4",
     "lodash": "^4.13.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
   },
   "homepage": "https://github.com/auth0/contact-form#readme",
   "dependencies": {
-    "bootstrap": "^3.3.7",
-    "jquery": "^2.2.4",
+    "bootstrap": "^3.3.6",
     "lodash": "^4.13.1"
   },
   "peerDependencies": {

--- a/src/contact-form-signup.jade
+++ b/src/contact-form-signup.jade
@@ -6,7 +6,7 @@
           span(aria-hidden="true") &times;
         h4.modal-title#contact-form-title= modalTitle
       .modal-body
-        p Please fill out this form to get started.  
+        p Please fill out this form to get started. We'll be in contact shortly to setup your subscription.
         .form-group
           label.sr-only(for="contact-form-modal__name") Name
           input.form-control.contact-form-modal__name#contact-form-modal__name(type="text", placeholder="Name", autocomplete="section-contact name", name="name", required)

--- a/src/contact-form-signup.jade
+++ b/src/contact-form-signup.jade
@@ -1,0 +1,22 @@
+.modal.fade.contact-form-modal#contact-form-modal(tabindex="-1", role="dialog", aria-labelledby="contact-form-title")
+  .modal-dialog
+    form.modal-content.contact-form-modal__form#contact-form-modal__form
+      .modal-header.has-border
+        button.close(class="close", data-dismiss="modal", aria-label="Close")
+          span(aria-hidden="true") &times;
+        h4.modal-title#contact-form-title= modalTitle
+      .modal-body
+        p Please fill out this form to get started.  
+        .form-group
+          label.sr-only(for="contact-form-modal__name") Name
+          input.form-control.contact-form-modal__name#contact-form-modal__name(type="text", placeholder="Name", autocomplete="section-contact name", name="name", required)
+          span.required *
+        .form-group
+          label.sr-only(for="contact-form-modal__email") Email address
+          input.form-control.contact-form-modal__email#contact-form-modal__email(type="email", placeholder="Email address", autocomplete="section-contact email", name="email", required)
+          span.required *
+        .form-group
+          label.sr-only(for="contact-form-modal__company") Company
+          input.form-control.contact-form-modal__company#contact-form-modal__company(type="text", placeholder="Company", autocomplete="section-contact organization", name="company")
+      .modal-footer
+        button.btn.btn-success.btn-lg.animated.contact-form-modal__submit#contact-form-modal__submit(type="submit") Send

--- a/src/contact-form.js
+++ b/src/contact-form.js
@@ -4,6 +4,7 @@ import jQuery from 'jquery';
 import { assign } from 'lodash';
 import 'bootstrap/js/modal';
 import template from './contact-form.jade';
+import template_signup from './contact-form-signup.jade';
 import './contact-form.styl';
 
 // Globals apis
@@ -19,7 +20,7 @@ class ContactForm {
     onFormSuccess: () => {},
     onFormFail: () => {},
     postUrl: 'https://webtask.it.auth0.com/api/run/auth0-generic/contact-form-mandrill',
-    modalTitle: 'Contact Sales Team'
+    modalTitle: 'Contact Sales Team',
   }
 
   constructor(options) {
@@ -57,7 +58,14 @@ class ContactForm {
     const { modalRoot } = this.getElements();
 
     modalRoot.remove();
-    $('body').append(template({ modalTitle }));
+
+    //display the sign up form or standard form
+    if (this.options.signUp) {
+      $('body').append(template_signup({ modalTitle }));
+    }
+    else {
+      $('body').append(template({ modalTitle }));
+    }
   }
 
   /**


### PR DESCRIPTION
This PR adds a new minimal "signup" form which can be displayed when `signup:true` is passed in the options. This will be used for the starter plan signup.